### PR TITLE
gh release list pipeline

### DIFF
--- a/.github/actions/gh/action.yaml
+++ b/.github/actions/gh/action.yaml
@@ -1,0 +1,17 @@
+name: gh
+description: GitHub CLI Action
+inputs:
+  token:
+    description: GitHub token to authenticate with the GitHub CLI
+    required: true
+    default: ${{ github.token }}
+
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run GitHub CLI
+      run: gh release list --repo microsoft/vscode | head -n 1
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -1,0 +1,15 @@
+name: gh release test
+on:
+  pull_request:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: gh release test
+        run: |
+          gh release list --repo microsoft/vscode | head -n 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -8,8 +8,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: gh release test
-        run: |
-          gh release list --repo microsoft/vscode | head -n 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: gh
+        uses: ./.github/actions/gh
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
use gh release list --repo <owner/repo> with `|` will make exit code not be 0, this behavior is only appear in composite action.

`gh release list --repo microsoft/vscode | head -n 1`
`gh release list` use with pipeline's exit code will be 141, but the result is still work. just exit code will be 141.